### PR TITLE
Fix 'this' context on acquire/released method

### DIFF
--- a/src/amqp/iomonad.js
+++ b/src/amqp/iomonad.js
@@ -145,7 +145,7 @@ module.exports = function (options, type, factory, target, close) {
         }.bind(this));
         this.once('released', function () {
           reject(new Error(`Cannot reacquire released ${type} '${this.name}'`));
-        });
+        }.bind(this));
       }.bind(this));
     },
     operate: function (call, args) {


### PR DESCRIPTION
We need to bind the released function so we can properly access the name property in the context, otherwise `this` will be undefined

![image](https://user-images.githubusercontent.com/2022343/53371423-f7c9ff00-392e-11e9-9ed2-0352da68a527.png)
